### PR TITLE
Feat: 상품 수정 페이지 구현

### DIFF
--- a/src/components/postImg/PostImgList.tsx
+++ b/src/components/postImg/PostImgList.tsx
@@ -1,0 +1,109 @@
+import { Children, useEffect, useRef, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { imgFilesState, imgUrlListState } from '../../store/atom';
+
+export default function PostImgList({ prevThumbnails }: { prevThumbnails: string[] }) {
+  const [files, setFiles] = useRecoilState<File[]>(imgFilesState);
+  const [imgUrls, setImgUrls] = useRecoilState<string[]>(imgUrlListState);
+  const [allThumbnails, setAllThumbnails] = useState<string[]>(prevThumbnails);
+  const imageRef = useRef<HTMLInputElement | null>(null);
+  const maxFileCount = 10;
+
+  useEffect(() => {
+    setImgUrls(prevThumbnails);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  /* 이미지 업로드 버튼 관련 메서드들 */
+  const onUploadBtnClick = () => {
+    if (!imageRef.current) {
+      return;
+    }
+    imageRef.current.click();
+  };
+
+  const onUploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) {
+      return;
+    }
+    const remainFileCount = maxFileCount - allThumbnails.length;
+    if (e.target.files.length > remainFileCount) {
+      // eslint-disable-next-line no-alert
+      return alert(`사진은 최대 ${maxFileCount}개까지 첨부 가능합니다.`);
+    }
+    const newFiles = Array.from(e.target.files);
+    const allFiles = [...files, ...newFiles];
+    setFiles(allFiles);
+
+    const urlList = newFiles.map((file) => URL.createObjectURL(file));
+    setAllThumbnails([...allThumbnails, ...urlList]);
+  };
+
+  const handleRemove = (idx: number) => {
+    if (prevThumbnails.includes(allThumbnails[idx])) {
+      /* 기존 사진 삭제하는 경우 */
+      const updatedUrls = imgUrls.filter((_, i) => i !== idx);
+      setImgUrls(updatedUrls);
+    } else {
+      /* 새로 추가한 사진 삭제하는 경우 */
+      const updatedFiles = files.filter((_, i) => i !== idx - imgUrls.length);
+      URL.revokeObjectURL(allThumbnails[idx]);
+      setFiles([...updatedFiles]);
+    }
+    const updatedThumbnails = allThumbnails.filter((_, i) => i !== idx);
+    setAllThumbnails(updatedThumbnails);
+  };
+
+  return (
+    <div className='w-full max-w-lg mx-auto md:max-w-5xl md:mt-24'>
+      <div className='flex h-32 mb-6 overflow-x-auto md:h-44'>
+        {allThumbnails.map((url, idx) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={url + idx} className='mr-4 avatar'>
+            <div className='relative w-24 h-24 rounded-xl md:w-36 md:h-36'>
+              <img src={url} alt='uploaded_image' />
+              <button
+                onClick={() => handleRemove(idx)}
+                className='absolute top-1 right-1 btn btn-xs md:btn-sm btn-circle btn-neutral'
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  className='w-4 h-4 md:w-6 md:h-6'
+                  fill='none'
+                  viewBox='0 0 24 24'
+                  stroke='currentColor'
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth='2'
+                    d='M6 18L18 6M6 6l12 12'
+                  />
+                </svg>
+              </button>
+            </div>
+          </div>
+        ))}
+        {Children.toArray(
+          [...Array(maxFileCount - allThumbnails.length)].map(() => (
+            <div className='mr-4 avatar'>
+              <div className='w-24 h-24 border-2 rounded-xl md:w-36 md:h-36' />
+            </div>
+          )),
+        )}
+      </div>
+      <input
+        type='file'
+        accept='image/*'
+        name='thumbnail'
+        ref={imageRef}
+        onChange={onUploadImage}
+        className='hidden'
+        multiple
+      />
+      <button type='button' onClick={onUploadBtnClick} className='mb-6 btn btn-neutral'>
+        이미지 업로드
+      </button>
+    </div>
+  );
+}

--- a/src/components/postImg/PostImgList.tsx
+++ b/src/components/postImg/PostImgList.tsx
@@ -1,13 +1,13 @@
 import { Children, useEffect, useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 import { imgFilesState, imgUrlListState } from '../../store/atom';
+import { MAXFILECOUNT } from '../../constants';
 
 export default function PostImgList({ prevThumbnails }: { prevThumbnails: string[] }) {
   const [files, setFiles] = useRecoilState<File[]>(imgFilesState);
   const [imgUrls, setImgUrls] = useRecoilState<string[]>(imgUrlListState);
   const [allThumbnails, setAllThumbnails] = useState<string[]>(prevThumbnails);
   const imageRef = useRef<HTMLInputElement | null>(null);
-  const maxFileCount = 10;
 
   useEffect(() => {
     setImgUrls(prevThumbnails);
@@ -26,10 +26,10 @@ export default function PostImgList({ prevThumbnails }: { prevThumbnails: string
     if (!e.target.files) {
       return;
     }
-    const remainFileCount = maxFileCount - allThumbnails.length;
+    const remainFileCount = MAXFILECOUNT - allThumbnails.length;
     if (e.target.files.length > remainFileCount) {
       // eslint-disable-next-line no-alert
-      return alert(`사진은 최대 ${maxFileCount}개까지 첨부 가능합니다.`);
+      return alert(`사진은 최대 ${MAXFILECOUNT}개까지 첨부 가능합니다.`);
     }
     const newFiles = Array.from(e.target.files);
     const allFiles = [...files, ...newFiles];
@@ -85,7 +85,7 @@ export default function PostImgList({ prevThumbnails }: { prevThumbnails: string
           </div>
         ))}
         {Children.toArray(
-          [...Array(maxFileCount - allThumbnails.length)].map(() => (
+          [...Array(MAXFILECOUNT - allThumbnails.length)].map(() => (
             <div className='mr-4 avatar'>
               <div className='w-24 h-24 border-2 rounded-xl md:w-36 md:h-36' />
             </div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
 export const kakaoSigninLink = `https://kauth.kakao.com/oauth/authorize?client_id=${
   import.meta.env.VITE_REST_API_KEY
 }&redirect_uri=${import.meta.env.VITE_REDIRECT_URI}&response_type=code`;
+
+export const MAXFILECOUNT = 10;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -125,4 +125,8 @@ export const handlers = [
     wishHistoryData.push(req as IWishHistoryData);
     return HttpResponse.json(wishHistoryData);
   }),
+  http.put('/goods/:goodsId', async ({ request }) => {
+    const req = await request.formData();
+    return HttpResponse.formData(req);
+  }),
 ];

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -25,15 +25,15 @@ export default function Router() {
         <Route path='/signin' element={<SignIn />} />
         <Route path='/signup' element={<SignUp />} />
         <Route path='/posts/:id' element={<PostDetail />} />
-        <Route path='/purchase-history' element={<PurchaseHistory />} />
         <Route path='/posts/new' element={<PostCreate />} />
+        <Route path='/posts/edit/:id' element={<PostEdit />} />
+        <Route path='/purchase-history' element={<PurchaseHistory />} />
         <Route path='/sales-history' element={<SalesHistory />} />
         <Route path='/wish-history' element={<WishHistory />} />
       </Route>
       <Route path='/mypage' element={<MyPage />} />
       <Route path='/mypage/update' element={<ProfileUpdate />} />
       <Route path='/auth/kakao' element={<KakaoRedirection />} />
-      <Route path='/posts/edit/:id' element={<PostEdit />} />
       <Route path='/shop/:id' element={<Shop />} />
       <Route path='/mypage/charge' element={<PointCharge />} />
       <Route path='/mypage/transfer' element={<Transfer />} />

--- a/src/routes/MyPage.tsx
+++ b/src/routes/MyPage.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import Profile from '../components/Profile/Profile';
+import Profile from '../components/profile/Profile';
 import { Link } from 'react-router-dom';
 import logo from '../assets/logo.webp';
 import { useResignMutation } from '../service/mypage/useUserQueries';
@@ -15,7 +15,7 @@ export default function MyPage() {
   const { mutate, isError } = useResignMutation(dialogRef);
 
   const handleResign = () => {
-    mutate({ password: `${password}` });
+    mutate({ password });
   };
 
   return (

--- a/src/routes/PostDetail.tsx
+++ b/src/routes/PostDetail.tsx
@@ -112,7 +112,13 @@ export default function PostDetail() {
               )}
             </button>
             <h3 className='flex-1 text-xl font-bold'>{addComma(data!.price)}원</h3>
-            <button className='btn btn-primary md:btn-lg'>채팅하기</button>
+            {isAutor ? (
+              <Link to={`/posts/edit/${goodsId}`} className='btn btn-primary md:btn-lg'>
+                수정하기
+              </Link>
+            ) : (
+              <button className='btn btn-primary md:btn-lg'>채팅하기</button>
+            )}
           </div>
         </div>
       </div>

--- a/src/routes/PostEdit.tsx
+++ b/src/routes/PostEdit.tsx
@@ -1,134 +1,25 @@
-import { useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { IMapLocation } from '../types/interface';
-import logo from '../assets/logo.webp';
-import { Map, MapMarker, ZoomControl } from 'react-kakao-maps-sdk';
+import { useParams } from 'react-router-dom';
+import { useReadPostQuery } from '../service/post/useReadPostQuery';
+import PostCreate from './PostCreate';
 
 export default function PostEdit() {
-  const [result, setResult] = useState<IMapLocation>();
-  const [, setFiles] = useState<File[]>([]);
-  const imageRef = useRef<HTMLInputElement | null>(null);
+  const { id: goodsId } = useParams();
 
-  const onSubmit = () => {
-    console.log('form 전송');
-  };
+  const { data, isLoading } = useReadPostQuery(goodsId!);
 
-  const onUploadBtnClick = () => {
-    if (!imageRef.current) {
-      return;
-    }
-    imageRef.current.click();
-  };
-
-  const onUploadImage = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!e.target.files) {
-      return;
-    }
-    setFiles([...e.target.files]);
-  };
-
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
   return (
-    <>
-      <div className='flex h-20 px-3 py-3 md:px-7'>
-        <Link to='/'>
-          <div className='p-1 rounded-lg hover:bg-neutral-100 '>
-            <img src={logo} alt='logo img' className='w-12 h-12' />
-          </div>
-        </Link>
-      </div>
-      <div className='w-full px-5 md:mx-auto md:max-w-5xl'>
-        <h2 className='my-12 text-2xl font-bold text-center md:text-3xl'>상품 수정</h2>
-        <div className='w-full max-w-lg mx-auto md:max-w-5xl'>
-          <div className='flex mb-6 overflow-x-auto'>
-            <div className='mr-4 avatar'>
-              <div className='w-24 rounded-xl md:w-36'>
-                <img src='/#' alt='uploaded_image' />
-              </div>
-            </div>
-            <div className='mr-4 avatar'>
-              <div className='w-24 rounded-xl md:w-36'>
-                <img src='/#' alt='uploaded_image' />
-              </div>
-            </div>
-            <div className='mr-4 avatar'>
-              <div className='w-24 rounded-xl md:w-36'>
-                <img src='/#' alt='uploaded_image' />
-              </div>
-            </div>
-            <div className='mr-4 avatar'>
-              <div className='w-24 rounded-xl md:w-36'>
-                <img src='/#' alt='uploaded_image' />
-              </div>
-            </div>
-          </div>
-          <input
-            type='file'
-            accept='image/*'
-            name='thumbnail'
-            ref={imageRef}
-            onChange={onUploadImage}
-            className='hidden'
-            multiple
-          />
-          <button onClick={onUploadBtnClick} className='mb-6 btn btn-neutral'>
-            이미지 업로드
-          </button>
-        </div>
-        <form
-          onSubmit={onSubmit}
-          className='flex flex-col items-center justify-center w-full mb-10 gap-y-6 md:items-start'
-        >
-          <label
-            htmlFor='priceInput'
-            className='flex items-center w-full max-w-lg gap-2 input input-bordered md:max-w-5xl'
-          >
-            가격
-            <input id='priceInput' type='number' className='text-right grow' />
-          </label>
-          <label
-            htmlFor='nameInput'
-            className='flex items-center w-full max-w-lg gap-2 input input-bordered md:max-w-5xl'
-          >
-            상품 이름
-            <input id='nameInput' type='text' className='text-right grow' />
-          </label>
-          <textarea
-            placeholder='상세 내용'
-            className='w-full max-w-lg textarea textarea-bordered textarea-sm md:max-w-5xl'
-          />
-          <Map
-            id='map'
-            center={{
-              lat: 37.5696765,
-              lng: 126.976502,
-            }}
-            level={4}
-            onDragEnd={(map) => {
-              const latlng = map.getCenter();
-              setResult({
-                lat: latlng.getLat(),
-                lng: latlng.getLng(),
-              });
-            }}
-            className='w-full h-48 max-w-lg md:h-64 md:max-w-5xl'
-          >
-            {/* eslint-disable-next-line react/jsx-curly-brace-presence */}
-            <ZoomControl position={'RIGHT'} />
-            <MapMarker
-              position={{
-                lat: result ? result.lat : 37.5696765,
-                lng: result ? result.lng : 126.976502,
-              }}
-            />
-          </Map>
-          <input
-            type='text'
-            placeholder='상세 주소 입력'
-            className='w-full max-w-lg input input-bordered md:max-w-5xl'
-          />
-          <button className='w-full max-w-lg btn btn-primary md:max-w-32'>등록하기</button>
-        </form>
-      </div>
-    </>
+    <PostCreate
+      goods_id={goodsId}
+      goods_name={data!.goods_name}
+      price={data!.price}
+      description={data!.description}
+      curImages={data!.goods_images}
+      lat={data!.lat}
+      lng={data!.lng}
+      detail_location={data!.detail_location}
+    />
   );
 }

--- a/src/routes/Shop.tsx
+++ b/src/routes/Shop.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from 'react-router-dom';
 import logo from '../assets/logo.webp';
-import Profile from '../components/Profile/Profile';
+import Profile from '../components/profile/Profile';
 
 export default function Shop() {
   const { id } = useParams();

--- a/src/service/post/useReadPostQuery.ts
+++ b/src/service/post/useReadPostQuery.ts
@@ -4,7 +4,7 @@ import { IGoodsData } from '../../types/interface';
 
 export const useReadPostQuery = (goodsId: string) => {
   const { isLoading, data } = useQuery<IGoodsData>({
-    queryKey: ['goodsDetail'],
+    queryKey: ['goodsDetail', goodsId],
     queryFn: async () => (await axios.get(`/goods/${goodsId}`)).data,
   });
 

--- a/src/service/post/useUpdatePostMutation.tsx
+++ b/src/service/post/useUpdatePostMutation.tsx
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+
+export const useUpdatePostMutation = () => {
+  const { mutate } = useMutation({
+    mutationFn: async ({ post, goods_id }: { post: FormData; goods_id: string }) =>
+      (
+        await axios.put(`/goods/${goods_id}`, post, {
+          headers: {
+            'Content-Type': 'multipart/form-data',
+          },
+        })
+      ).data,
+  });
+
+  return mutate;
+};

--- a/src/service/post/useUpdatePostMutation.tsx
+++ b/src/service/post/useUpdatePostMutation.tsx
@@ -1,7 +1,9 @@
 import { useMutation } from '@tanstack/react-query';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 export const useUpdatePostMutation = () => {
+  const navigate = useNavigate();
   const { mutate } = useMutation({
     mutationFn: async ({ post, goods_id }: { post: FormData; goods_id: string }) =>
       (
@@ -11,6 +13,9 @@ export const useUpdatePostMutation = () => {
           },
         })
       ).data,
+    onSuccess: (res) => {
+      navigate(`/posts/${res.id}`);
+    },
   });
 
   return mutate;

--- a/src/store/atom.ts
+++ b/src/store/atom.ts
@@ -11,3 +11,13 @@ export const homeListState = atom<IMapLocation[]>({
   key: 'homeList',
   default: [],
 });
+
+export const imgFilesState = atom<File[]>({
+  key: 'imgFiles',
+  default: [],
+});
+
+export const imgUrlListState = atom<string[]>({
+  key: 'imgUrlList',
+  default: [],
+});

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -85,7 +85,7 @@ export interface ICardListItemProps {
 
 export interface IPostCreate {
   goods_name: string;
-  price: string;
+  price: number;
   description: string;
   goods_images: File[];
   lat: number;
@@ -109,4 +109,9 @@ export interface IGoodsData {
   lat: number;
   lng: number;
   detail_location: string;
+}
+
+export interface IEditPostData extends IPostCreate {
+  goods_id: string;
+  curImages: string[];
 }


### PR DESCRIPTION
### ⭐ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 문서 추가
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 📌 관련 이슈
closed #39 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

### ✨ 변경 사항
- 상품 상세 페이지에서 '수정하기' 버튼 조건부 렌더링으로 구현했습니다.
- 수정하기 버튼을 누르면 수정하기 페이지로 이동하며, 기존 상품 데이터를 조회합니다.
- 수정 완료한 데이터는 put으로 서버에 전송되며, 상품 상세 페이지로 이동합니다.
- 사진 업로드/삭제 코드가 길어져 파일을 분리했습니다.
- **게시글 작성 페이지와 게시글 수정 페이지의 레이아웃이 동일해 props 값을 전달해 쓰는 것으로 변경했습니다.**

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
