### PR TITLE
Feat: 판매자 정보 페이지 조회

### DIFF
--- a/src/components/common/CardListPage.tsx
+++ b/src/components/common/CardListPage.tsx
@@ -1,12 +1,12 @@
 import { Link } from 'react-router-dom';
-import { IPurchaseHistoryData, IWishHistoryData } from '../../types/interface';
+import { IPurchaseHistoryData, ISalesHistoryData, IWishHistoryData } from '../../types/interface';
 import CardListItem from './CardListItem';
 
 export default function CardListPage({
   data,
   title,
 }: {
-  data: IPurchaseHistoryData[] | IWishHistoryData[];
+  data: IPurchaseHistoryData[] | IWishHistoryData[] | ISalesHistoryData[];
   title: string;
 }) {
   return (

--- a/src/components/profile/Profile.tsx
+++ b/src/components/profile/Profile.tsx
@@ -1,19 +1,19 @@
-import { useProfileDataQuery } from '../../service/mypage/useUserQueries';
+import { IProfileData } from '../../types/interface';
 import Star from './Star';
 
-export default function Profile() {
-  const { profile, badge, isLoading } = useProfileDataQuery();
-
-  if (isLoading) {
-    return <div>Loading...</div>;
-  }
+export default function Profile({
+  nick_name,
+  profile_image,
+  star,
+  badgeList,
+}: Partial<IProfileData>) {
   return (
     <div className='w-full max-w-md mx-auto h-36 md:flex-auto md:m-0'>
       <div className='h-full pb-8 card card-side md:pb-0'>
         <div className='avatar'>
           <div className='mr-4 w-28 rounded-xl md:w-36 md:mr-8'>
-            {profile!.profile_image ? (
-              <img src={profile!.profile_image} alt='profile_image' />
+            {profile_image ? (
+              <img src={profile_image} alt='profile_image' />
             ) : (
               <svg
                 xmlns='http://www.w3.org/2000/svg'
@@ -30,14 +30,14 @@ export default function Profile() {
         </div>
         <div className='flex flex-col items-start justify-around w-full'>
           <div className='flex items-center'>
-            <h2 className='mr-2 card-title'>{profile!.nick_name}</h2>
-            <Star star={profile!.star} />
+            <h2 className='mr-2 card-title'>{nick_name}</h2>
+            <Star star={star!} />
           </div>
           <div className='justify-end card-actions'>
-            {badge!.badge.includes('sell') && (
+            {badgeList!.includes('sell') && (
               <div className='badge badge-secondary badge-outline md:badge-lg'>판매왕</div>
             )}
-            {badge!.badge.includes('manner') && (
+            {badgeList!.includes('manner') && (
               <div className='badge badge-primary badge-outline md:badge-lg'>매너왕</div>
             )}
           </div>

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -8,14 +8,14 @@ import { goodsData } from './data/goodsDetailData';
 
 /* profile mock data */
 export const profileData: IProfileData = {
+  member_id: 1,
   nick_name: '홍길동',
   phone_number: '010-1234-5678',
   profile_image: 'https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg',
   star: 3.5,
+  badgeList: ['sell'],
 };
-const badgeData = {
-  badge: ['sell'],
-};
+
 const tokenData = { accessToken: 'accessaccessaccess', refreshToken: 'refreshrefreshrefresh' };
 
 let wishHistoryData: IWishHistoryData[] = [
@@ -58,9 +58,6 @@ export const handlers = [
   http.get('/member/profile', () => {
     return HttpResponse.json(profileData);
   }),
-  http.get('/member/badge', () => {
-    return HttpResponse.json(badgeData);
-  }),
   http.post('/auth/kakao', () => {
     return HttpResponse.json(tokenData);
   }),
@@ -95,7 +92,7 @@ export const handlers = [
     const req = await request.formData();
     return HttpResponse.formData(req);
   }),
-  http.get('/api/goods/sales', () => HttpResponse.json(salesHistoryData)),
+  http.get('/api/goods/sell-list/:sellerId', () => HttpResponse.json(salesHistoryData)),
   http.get('/api/goods/likes', () => HttpResponse.json(wishHistoryData)),
   http.delete('/api/goods/:goodsId/likes', ({ params }) => {
     wishHistoryData = wishHistoryData.filter((item) => item.id !== Number(params.goodsId));
@@ -147,5 +144,8 @@ export const handlers = [
     const req = (await request.json()) as { email: string; code: number };
 
     return HttpResponse.json(req.code === 123);
+  }),
+  http.get('/member/:sellerId/profile', () => {
+    return HttpResponse.json(profileData);
   }),
 ];

--- a/src/routes/MyPage.tsx
+++ b/src/routes/MyPage.tsx
@@ -2,7 +2,7 @@ import { useRef, useState } from 'react';
 import Profile from '../components/profile/Profile';
 import { Link } from 'react-router-dom';
 import logo from '../assets/logo.webp';
-import { useResignMutation } from '../service/mypage/useUserQueries';
+import { useProfileQuery, useResignMutation } from '../service/mypage/useUserQueries';
 
 export default function MyPage() {
   const dialogRef = useRef<HTMLDialogElement>(null);
@@ -12,6 +12,7 @@ export default function MyPage() {
     dialogRef.current?.showModal();
   };
 
+  const { data: profile, isLoading } = useProfileQuery();
   const { mutate, isError } = useResignMutation();
 
   const handleResign = () => {
@@ -30,7 +31,14 @@ export default function MyPage() {
       <div className='w-full px-5 md:mx-auto md:max-w-5xl'>
         <h1 className='my-12 text-2xl font-bold text-center md:text-3xl'>마이페이지</h1>
         <div className='flex flex-col md:flex-row md:items-end'>
-          <Profile />
+          {!isLoading && (
+            <Profile
+              nick_name={profile!.nick_name}
+              profile_image={profile!.profile_image}
+              star={profile!.star}
+              badgeList={profile!.badgeList}
+            />
+          )}
           <Link
             to='/mypage/update'
             className='w-full max-w-md mx-auto btn btn-lg btn-neutral no-animation md:flex-none md:btn md:btn-neutral md:w-28 md:mr-0'

--- a/src/routes/SalesHistory.tsx
+++ b/src/routes/SalesHistory.tsx
@@ -1,8 +1,10 @@
 import CardListPage from '../components/common/CardListPage';
 import { useSalesHistoryQuery } from '../service/mypage/useSalseHistoryQuery';
+import { useProfileQuery } from '../service/mypage/useUserQueries';
 
 export default function SalesHistory() {
-  const { data, isLoading } = useSalesHistoryQuery();
-  if (isLoading) return <h1>loading...</h1>;
+  const { data: profile, isLoading: profileLoading } = useProfileQuery();
+  const { data, isLoading } = useSalesHistoryQuery(String(profile!.member_id));
+  if (isLoading || profileLoading) return <h1>loading...</h1>;
   return <CardListPage data={data!} title='판매 내역' />;
 }

--- a/src/routes/Shop.tsx
+++ b/src/routes/Shop.tsx
@@ -1,11 +1,15 @@
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import logo from '../assets/logo.webp';
 import Profile from '../components/profile/Profile';
+import { useSellerProfileQuery } from '../service/mypage/useUserQueries';
+import { useSalesHistoryQuery } from '../service/mypage/useSalseHistoryQuery';
+import CardListItem from '../components/common/CardListItem';
 
 export default function Shop() {
-  // const { id } = useParams();
+  const { id } = useParams();
 
-  /* 페이지네이션과 api 연결 추후에 추가 */
+  const { data: profile, isLoading: profileLoading } = useSellerProfileQuery(id!);
+  const { data: salesData, isLoading: salesLoading } = useSalesHistoryQuery(id!);
 
   return (
     <>
@@ -19,13 +23,59 @@ export default function Shop() {
       <div className='w-full px-5 md:mx-auto md:max-w-5xl'>
         <h1 className='my-12 text-2xl font-bold text-center md:text-3xl'>판매자 프로필</h1>
         <div className='flex flex-col md:flex-row md:items-end'>
-          <Profile />
+          {!profileLoading && (
+            <Profile
+              nick_name={profile!.nick_name}
+              profile_image={profile!.profile_image}
+              star={profile!.star}
+              badgeList={profile!.badgeList}
+            />
+          )}
         </div>
-      </div>
-      <div className='w-full max-w-md px-5 mx-auto mt-8 border-t-2 md:max-w-5xl'>
-        <h2 className='my-12 text-xl font-bold md:text-2xl'>판매 목록</h2>
+        <div className='w-full max-w-md mx-auto border-t-2 md:max-w-5xl md:mt-8'>
+          <h2 className='mt-8 mb-4 ml-4 text-xl font-bold md:text-2xl'>판매 목록</h2>
+          {!salesLoading && (
+            <ul className='flex flex-col items-center justify-center w-full max-w-md mx-auto mb-20 md:max-w-5xl gap-y-3'>
+              {salesData!.length === 0 ? (
+                <div className='flex flex-col items-center justify-center w-full h-96 gap-y-5'>
+                  <svg
+                    xmlns='http://www.w3.org/2000/svg'
+                    fill='none'
+                    viewBox='0 0 24 24'
+                    strokeWidth={1.5}
+                    stroke='currentColor'
+                    className='w-10 h-10'
+                  >
+                    <path
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
+                      d='M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 0 0-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 0 0-16.536-1.84M7.5 14.25 5.106 5.272M6 20.25a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Zm12.75 0a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z'
+                    />
+                  </svg>
+                  <h1 className='text-xl font-bold'>결과가 없습니다.</h1>
+                  <Link to='/'>
+                    <button className='btn btn-outline'>물건 보러 가기</button>
+                  </Link>
+                </div>
+              ) : (
+                salesData!.map((item) => {
+                  return (
+                    <CardListItem
+                      key={item.id}
+                      id={item.id}
+                      img={item.goods_thumbnail}
+                      name={item.goods_name}
+                      price={item.price}
+                      status={item.goods_status}
+                      uploadedBefore={item.uploadedBefore}
+                    />
+                  );
+                })
+              )}
+            </ul>
+          )}
 
-        {/* 판매 물품 카드 1 */}
+          {/* 판매 물품 카드 1}
         <div className='h-full py-4 mb-4 border-2 card card-side md:py-0'>
           <div className='avatar'>
             <div className='mx-4 w-28 rounded-xl md:w-36 md:mr-8 md:ml-0'>
@@ -42,7 +92,7 @@ export default function Shop() {
           </div>
         </div>
         {/* 판매 물품 카드 2 */}
-        <div className='h-full py-4 mb-4 border-2 card card-side md:py-0'>
+          {/* <div className='h-full py-4 mb-4 border-2 card card-side md:py-0'>
           <div className='avatar'>
             <div className='mx-4 w-28 rounded-xl md:w-36 md:mr-8 md:ml-0'>
               <img src='/#' alt='profile_image' />
@@ -55,6 +105,7 @@ export default function Shop() {
               <p className='text-xl font-bold'>12,000원</p>
             </div>
           </div>
+        </div> */}
         </div>
       </div>
     </>

--- a/src/service/mypage/useSalseHistoryQuery.ts
+++ b/src/service/mypage/useSalseHistoryQuery.ts
@@ -1,10 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
+import { ISalesHistoryData } from '../../types/interface';
 
-export const useSalesHistoryQuery = () => {
-  const { data, isLoading } = useQuery({
+export const useSalesHistoryQuery = (sellerId: string) => {
+  const { data, isLoading } = useQuery<ISalesHistoryData[]>({
     queryKey: ['salesHistory'],
-    queryFn: async () => (await axios.get('/api/goods/sales')).data,
+    queryFn: async () => (await axios.get(`/api/goods/sell-list/${sellerId}`)).data,
   });
   return { data, isLoading };
 };

--- a/src/service/mypage/useUserQueries.ts
+++ b/src/service/mypage/useUserQueries.ts
@@ -12,14 +12,13 @@ export const useProfileQuery = () => {
   return { isLoading, data };
 };
 
-export const useProfileDataQuery = () => {
-  const { data: profile, isLoading: profileLoading } = useProfileQuery();
-  const { data: badge, isLoading: badgeLoading } = useQuery({
-    queryKey: ['badge'],
-    queryFn: async () => (await axios.get('/member/badge')).data,
+export const useSellerProfileQuery = (sellerId: string) => {
+  const { isLoading, data } = useQuery<IProfileData>({
+    queryKey: ['seller'],
+    queryFn: async () => (await axios.get(`/member/${sellerId}/profile`)).data,
   });
 
-  return { profile, badge, isLoading: profileLoading || badgeLoading };
+  return { isLoading, data };
 };
 
 export const useUpdateProfileMutation = () => {

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -9,10 +9,12 @@ export type FormValueTypes = {
 
 /* profile mock interface */
 export interface IProfileData {
+  member_id: number;
   nick_name: string;
   phone_number: string;
   profile_image: string;
   star: number;
+  badgeList: string[];
 }
 
 /* profile update mock interface */


### PR DESCRIPTION
### ⭐ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 문서 추가
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 📌 관련 이슈
closed #56 
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

### ✨ 변경 사항
- 판매자 정보 페이지에 판매자 프로필과 판매내역을 조회하는 기능을 추가했습니다.
- 판매목록 조회 api url과 회원 정보 조회 api 명세가 수정돼 맞춰서 수정해뒀습니다.
- 판매 목록이 page 형태로 들어오는 것(무한스크롤)은 추후에 추가할 예정입니다.
- salesHistory 컴포넌트를 보시면 프로필 조회 쿼리에서 받아온 id를 판매목록조회 쿼리에 사용해야 하는데 동작순서에 문제가 없는지 모르겠습니다. (현재는 순서대로 잘 들어오긴 합니다...)


### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
