### PR TITLE
Feat: 모바일 UI bottomSheet,메인화면 리스트 무한스크롤

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^5.32.0",
         "@types/sockjs-client": "^1.5.4",
         "axios": "^1.6.8",
+        "framer-motion": "^11.2.10",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3486,6 +3487,30 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.2.10.tgz",
+      "integrity": "sha512-/gr3PLZUVFCc86a9MqCUboVrALscrdluzTb3yew+2/qKBU8CX6nzs918/SRBRCqaPbx0TZP10CB6yFgK2C5cYQ==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5939,6 +5964,11 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.32.0",
     "@types/sockjs-client": "^1.5.4",
     "axios": "^1.6.8",
+    "framer-motion": "^11.2.10",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/bottomSheet/BottomSheet.tsx
+++ b/src/components/bottomSheet/BottomSheet.tsx
@@ -1,0 +1,53 @@
+import { IBottomSheet } from '../../types/interface';
+import useBottomSheet from '../../util/useBottomSheet';
+import BottomSheetContent from './BottomSheetContent';
+import BottomSheetHeader from './BottomSheetHeader';
+import { motion } from 'framer-motion';
+import HomeListItem from '../home/HomeListItem';
+import Observer from '../common/Observer';
+
+export default function BottomSheet({ products, hasNext, loadMore }: IBottomSheet) {
+  const { onDragEnd, controls, setIsOpen, isOpen } = useBottomSheet();
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
+    <div
+      className={`block md:hidden ${
+        isOpen && 'bg-[rgba(0,0,0,.7)] z-[100] absolute top-0 left-0 w-full h-screen'
+      }`}
+      onClick={() => isOpen && setIsOpen(false)}
+    >
+      <motion.div
+        drag='y'
+        onDragEnd={onDragEnd}
+        initial='hidden'
+        animate={controls}
+        transition={{
+          type: 'spring',
+          damping: 40,
+          stiffness: 400,
+        }}
+        variants={{
+          visible: { y: 100 },
+          hidden: { y: '100%' },
+        }}
+        dragConstraints={{ top: 0 }}
+        dragElastic={0.7}
+        className={`flex-col block md:hidden m-auto fixed z-30 top-14 left-0 right-0 rounded-t-xl bg-white shadow-lg `}
+      >
+        <BottomSheetHeader />
+        <BottomSheetContent>
+          <HomeListItem products={products} />
+          <Observer hasNext={hasNext} loadMore={loadMore} />
+        </BottomSheetContent>
+      </motion.div>
+
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div
+        onClick={() => setIsOpen(true)}
+        className='absolute z-20 flex items-center justify-center w-12 h-12 text-sm text-white transition-colors duration-200 bg-black rounded-full cursor-pointer md:hidden bottom-5 left-5 md:p-4 md:bottom-8 md:left-8 hover:bg-neutral-700'
+      >
+        리스트
+      </div>
+    </div>
+  );
+}

--- a/src/components/bottomSheet/BottomSheetContent.tsx
+++ b/src/components/bottomSheet/BottomSheetContent.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function BottomSheetContent({ children }: { children: React.ReactNode }) {
+  return <ul className='p-5 pb-36 h-[90vh] overflow-y-auto'>{children}</ul>;
+}

--- a/src/components/bottomSheet/BottomSheetHeader.tsx
+++ b/src/components/bottomSheet/BottomSheetHeader.tsx
@@ -1,0 +1,7 @@
+export default function BottomSheetHeader() {
+  return (
+    <div className='h-[48px] cursor-pointer bg-white rounded-t-xl shadow-md relative pt-4 pb-1'>
+      <div className='w-[50px] h-1 rounded bg-black m-auto' />
+    </div>
+  );
+}

--- a/src/components/common/LoadingSpinner.tsx
+++ b/src/components/common/LoadingSpinner.tsx
@@ -1,6 +1,6 @@
 export default function LoadingSpinner() {
   return (
-    <div className='absolute top-0 left-0 flex items-center justify-center w-full h-screen border gap-x-5'>
+    <div className='absolute top-0 left-0 flex items-center justify-center w-full h-screen bg-white border gap-x-5'>
       <span className='loading loading-spinner loading-lg' />
       <h1 className='text-lg font-bold md:text-2xl'>로딩 중 입니다...</h1>
     </div>

--- a/src/components/common/Observer.tsx
+++ b/src/components/common/Observer.tsx
@@ -1,14 +1,8 @@
-import { InfiniteQueryObserverResult } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { IObserver } from '../../types/interface';
 
-export default function Observer({
-  loadMore,
-  hasNext,
-}: {
-  loadMore: () => Promise<InfiniteQueryObserverResult>;
-  hasNext: boolean;
-}) {
+export default function Observer({ loadMore, hasNext }: IObserver) {
   const { ref, inView } = useInView({ threshold: 1, delay: 500 });
 
   useEffect(() => {
@@ -17,7 +11,7 @@ export default function Observer({
     }
   }, [inView, loadMore]);
   return (
-    <div>
+    <div className='flex items-center justify-center'>
       {hasNext ? (
         <div className='text-center'>
           <span ref={ref} className='my-5 loading loading-spinner loading-lg' />

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -19,7 +19,7 @@ export default function Header() {
     navigate('/signup');
   };
   return (
-    <div className='fixed top-0 left-0 z-50 flex items-center justify-between w-full h-20 px-3 py-3 bg-white border-b md:px-7 gap-x-2'>
+    <div className='fixed top-0 left-0 z-40 flex items-center justify-between w-full h-20 px-3 py-3 bg-white border-b md:px-7 gap-x-2'>
       <Link to='/'>
         <div className='p-1 rounded-lg hover:bg-neutral-100 '>
           <img src={logo} alt='logo img' className='w-8 h-8 md:w-12 md:h-12' />

--- a/src/components/home/HomeList.tsx
+++ b/src/components/home/HomeList.tsx
@@ -1,25 +1,22 @@
 import { useRecoilValue } from 'recoil';
 import { homeListState } from '../../store/atom';
-import { Link } from 'react-router-dom';
-import { addComma } from '../../util/addComma';
+import BottomSheet from '../bottomSheet/BottomSheet';
+import HomeListItem from './HomeListItem';
+import Observer from '../common/Observer';
+import { IObserver } from '../../types/interface';
 
-export default function HomeList() {
+export default function HomeList({ hasNext, loadMore }: IObserver) {
   const products = useRecoilValue(homeListState);
+  console.log(products);
 
   return (
-    <ul className='overflow-y-auto border h-96 md:h-full md:w-96 bg-rgba(255,255,255,.7)'>
-      {Array.isArray(products) &&
-        products.map((product) => (
-          <Link to={`posts/${product.goods_id}`} key={`_${product.goods_id}`}>
-            <li className='flex items-center justify-start p-3 border gap-x-5'>
-              <img src={product.thumbnail_url} alt='thumbnail' className='w-24 h-24 rounded-xl' />
-              <div className='font-bold'>
-                <h3 className='mb-3 text-xl'>{product.goods_name}</h3>
-                <p className='text-lg md:text-base'>{`${addComma(String(product.price))}원`}</p>
-              </div>
-            </li>
-          </Link>
-        ))}
-    </ul>
+    <>
+      <ul className='overflow-y-auto hidden md:block pb-28 h-full w-[400px] bg-rgba(255,255,255,.7)'>
+        <HomeListItem products={products} />
+        <Observer hasNext={hasNext} loadMore={loadMore} />
+      </ul>
+
+      <BottomSheet products={products} hasNext={hasNext} loadMore={loadMore} />
+    </>
   );
 }

--- a/src/components/home/HomeListItem.tsx
+++ b/src/components/home/HomeListItem.tsx
@@ -1,0 +1,27 @@
+import { IGoodsList } from '../../types/interface';
+import { Link } from 'react-router-dom';
+import { addComma } from '../../util/addComma';
+
+export default function HomeListItem({ products }: { products: IGoodsList[] }) {
+  return (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
+    <>
+      {Array.isArray(products) &&
+        products.map((product) => (
+          <Link to={`posts/${product.goods_id}`} key={`_${product.goods_id}`}>
+            <li className='flex items-center justify-start px-2 py-3 border-b md:p-3 gap-x-5'>
+              <img
+                src={product.thumbnail_url}
+                alt='thumbnail'
+                className='w-20 h-20 md:w-24 md:h-24 rounded-xl'
+              />
+              <div className='font-bold'>
+                <h3 className='mb-3 md:text-lg lg:text-xl'>{product.goods_name}</h3>
+                <p>{`${addComma(String(product.price))}원`}</p>
+              </div>
+            </li>
+          </Link>
+        ))}
+    </>
+  );
+}

--- a/src/components/home/ProductMarkers.tsx
+++ b/src/components/home/ProductMarkers.tsx
@@ -7,18 +7,38 @@ export default function ProductMarkers({ goodsList }: { goodsList: IGoodsList[] 
   const setListState = useSetRecoilState(homeListState);
   const searchList = useRecoilValue(searchResultState);
 
-  const handleClusterClick = (_: kakao.maps.MarkerClusterer, cluster: kakao.maps.Cluster) => {
-    const markerList = cluster.getMarkers().map((item) => item.getPosition().getLat().toFixed(10));
+  const handleClusterClick = async (_: kakao.maps.MarkerClusterer, cluster: kakao.maps.Cluster) => {
+    // const lat = cluster.getMarkers().map((item) => item.getPosition().getLat().toFixed(10))[0];
+    // const lng = cluster.getMarkers().map((item) => item.getPosition().getLat().toFixed(10))[0];
 
-    const res = goodsList?.filter((item) => {
-      const pos = new kakao.maps.LatLng(item.lat, item.lng).getLat().toFixed(10);
-      return markerList.findIndex((item) => item === pos) !== -1;
+    // const newPageData = (
+    //   await axios.get('/api/api/goods', {
+    //     params: { lat, lng, responseType: 'page' },
+    //   })
+    // ).data.content;
+    // console.log(newPageData);
+
+    // const res = goodsList?.filter((item) => {
+    //   const pos = new kakao.maps.LatLng(item.lat, item.lng).getLat().toFixed(10);
+    //   return lat.findIndex((item) => item === pos) !== -1;
+    // });
+    // setListState(res!);
+
+    const markers = cluster.getMarkers().map((item) => {
+      const position = item.getPosition();
+      return {
+        lat: position.getLat(),
+        lng: position.getLng(),
+      };
     });
-    setListState(res!);
+    console.log(markers);
   };
 
   const handleMarkerClick = (pos: IGoodsList) => {
     setListState([pos]);
+
+    const { lat, lng } = pos;
+    console.log({ lat, lng });
   };
 
   return (

--- a/src/components/home/ProductMarkers.tsx
+++ b/src/components/home/ProductMarkers.tsx
@@ -8,30 +8,17 @@ export default function ProductMarkers({ goodsList }: { goodsList: IGoodsList[] 
   const searchList = useRecoilValue(searchResultState);
 
   const handleClusterClick = async (_: kakao.maps.MarkerClusterer, cluster: kakao.maps.Cluster) => {
-    // const lat = cluster.getMarkers().map((item) => item.getPosition().getLat().toFixed(10))[0];
-    // const lng = cluster.getMarkers().map((item) => item.getPosition().getLat().toFixed(10))[0];
+    const bounds = cluster.getBounds();
+    const center = cluster.getCenter();
+    const northEast = bounds.getNorthEast();
+    const southWest = bounds.getSouthWest();
 
-    // const newPageData = (
-    //   await axios.get('/api/api/goods', {
-    //     params: { lat, lng, responseType: 'page' },
-    //   })
-    // ).data.content;
-    // console.log(newPageData);
-
-    // const res = goodsList?.filter((item) => {
-    //   const pos = new kakao.maps.LatLng(item.lat, item.lng).getLat().toFixed(10);
-    //   return lat.findIndex((item) => item === pos) !== -1;
-    // });
-    // setListState(res!);
-
-    const markers = cluster.getMarkers().map((item) => {
-      const position = item.getPosition();
-      return {
-        lat: position.getLat(),
-        lng: position.getLng(),
-      };
-    });
-    console.log(markers);
+    const payload = {
+      northEast: { lat: northEast.getLat(), lng: northEast.getLng() },
+      southWest: { lat: southWest.getLat(), lng: southWest.getLng() },
+      center: { lat: center.getLat(), lng: center.getLng() },
+    };
+    console.log(payload); // 백엔드에서 api 추가되면 전송
   };
 
   const handleMarkerClick = (pos: IGoodsList) => {

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -3,7 +3,7 @@ import HomeMap from '../components/home/HomeMap';
 import HomeAddr from '../components/home/HomeAddr';
 import { useState } from 'react';
 import { IMyLocation } from '../types/interface';
-import { useNearbyGoods } from '../service/map/useNearbyGoods';
+import { useNearbyGoodsPage, useNearbyGoodsList } from '../service/map/useNearbyGoods';
 import { useMemoHistory } from '../util/useMemoHistory';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 
@@ -17,15 +17,15 @@ export default function Home() {
     isLoading: true,
   });
 
-  const { data, isLoading, hasNextPage, fetchNextPage } = useNearbyGoods(state.center);
-  const products = useMemoHistory(data!);
-
+  const { page, hasNextPage, fetchNextPage } = useNearbyGoodsPage(state.center);
+  const { listdata, isLoading } = useNearbyGoodsList(state.center);
+  const pageData = useMemoHistory(page!);
   if (isLoading) return <LoadingSpinner />;
   return (
     <div className='absolute top-0 left-0 flex flex-col w-full h-full pt-20 overflow-hidden'>
       <HomeAddr />
       <div className='flex flex-col h-full md:flex-row-reverse'>
-        <HomeMap products={products!} setState={setState} state={state} />
+        <HomeMap listData={listdata} pageData={pageData!} setState={setState} state={state} />
         <HomeList hasNext={hasNextPage} loadMore={fetchNextPage} />
       </div>
     </div>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,14 +1,32 @@
 import HomeList from '../components/home/HomeList';
 import HomeMap from '../components/home/HomeMap';
 import HomeAddr from '../components/home/HomeAddr';
+import { useState } from 'react';
+import { IMyLocation } from '../types/interface';
+import { useNearbyGoods } from '../service/map/useNearbyGoods';
+import { useMemoHistory } from '../util/useMemoHistory';
+import LoadingSpinner from '../components/common/LoadingSpinner';
 
 export default function Home() {
+  const [state, setState] = useState<IMyLocation>({
+    center: {
+      lat: 0,
+      lng: 0,
+    },
+    errMsg: null,
+    isLoading: true,
+  });
+
+  const { data, isLoading, hasNextPage, fetchNextPage } = useNearbyGoods(state.center);
+  const products = useMemoHistory(data!);
+
+  if (isLoading) return <LoadingSpinner />;
   return (
     <div className='absolute top-0 left-0 flex flex-col w-full h-full pt-20 overflow-hidden'>
       <HomeAddr />
       <div className='flex flex-col h-full md:flex-row-reverse'>
-        <HomeMap />
-        <HomeList />
+        <HomeMap products={products!} setState={setState} state={state} />
+        <HomeList hasNext={hasNextPage} loadMore={fetchNextPage} />
       </div>
     </div>
   );

--- a/src/routes/SalesHistory.tsx
+++ b/src/routes/SalesHistory.tsx
@@ -5,7 +5,7 @@ import { usePaginatedSalesHistoryQuery } from '../service/mypage/useSalseHistory
 import { Link } from 'react-router-dom';
 import { getTime } from '../util/getTime';
 import { addComma } from '../util/addComma';
-import { useReduceHistory } from '../util/useReduceHistory';
+import { useMemoHistory } from '../util/useMemoHistory';
 import { ISalesHistoryData } from '../types/interface';
 
 export default function SalesHistory({ userId, loading }: { userId: string; loading: boolean }) {
@@ -13,7 +13,7 @@ export default function SalesHistory({ userId, loading }: { userId: string; load
     String(userId),
   );
 
-  const salesItems = useReduceHistory<ISalesHistoryData>(data!);
+  const salesItems = useMemoHistory<ISalesHistoryData>(data!);
 
   if (isLoading || loading) return <LoadingSpinner />;
   return (

--- a/src/routes/WishHistory.tsx
+++ b/src/routes/WishHistory.tsx
@@ -6,13 +6,13 @@ import { getTime } from '../util/getTime';
 import AddWishListButton from '../components/common/AddWishListButton';
 import HistoryPageContainer from '../components/common/HistoryPageContainer';
 import { addComma } from '../util/addComma';
-import { useReduceHistory } from '../util/useReduceHistory';
+import { useMemoHistory } from '../util/useMemoHistory';
 import { IWishHistoryData } from '../types/interface';
 
 export default function WishHistory() {
   const { data, isLoading, hasNextPage, fetchNextPage } = usePaginatedHistoryQuery();
 
-  const wishList = useReduceHistory<IWishHistoryData>(data!);
+  const wishList = useMemoHistory<IWishHistoryData>(data!);
 
   if (isLoading) return <LoadingSpinner />;
   return (

--- a/src/service/map/useNearbyGoods.ts
+++ b/src/service/map/useNearbyGoods.ts
@@ -1,10 +1,15 @@
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { IGoodsList } from '../../types/interface';
 
-export const useNearbyGoods = (payload: { lat: number; lng: number }) => {
-  const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery({
-    queryKey: ['nearby', `${payload.lat}_${payload.lng}`],
+export const useNearbyGoodsPage = (payload: { lat: number; lng: number }) => {
+  const {
+    data: page,
+    isLoading,
+    hasNextPage,
+    fetchNextPage,
+  } = useInfiniteQuery({
+    queryKey: ['nearbyPage', `${payload.lat}_${payload.lng}`],
     queryFn: async ({ pageParam }: { pageParam: number }) =>
       (
         await axios.get(`/api/api/goods`, {
@@ -13,6 +18,7 @@ export const useNearbyGoods = (payload: { lat: number; lng: number }) => {
             lng: payload.lng,
             page: pageParam,
             size: 5,
+            responseType: 'page',
           },
         })
       ).data.content as IGoodsList[],
@@ -20,5 +26,22 @@ export const useNearbyGoods = (payload: { lat: number; lng: number }) => {
     getNextPageParam: (lastPage, _, lastPageParams) =>
       lastPage.length ? lastPageParams + 1 : undefined,
   });
-  return { data, isLoading, hasNextPage, fetchNextPage };
+  return { page, isLoading, hasNextPage, fetchNextPage };
+};
+
+export const useNearbyGoodsList = (payload: { lat: number; lng: number }) => {
+  const {
+    data: listdata,
+    isLoading,
+    refetch: refetchList,
+  } = useQuery({
+    queryKey: ['nearbyList', `${payload.lat}_${payload.lng}`],
+    queryFn: async () =>
+      (
+        await axios.get(`/api/api/goods`, {
+          params: { lat: payload.lat, lng: payload.lng, responseType: 'list' },
+        })
+      ).data,
+  });
+  return { listdata, isLoading, refetchList };
 };

--- a/src/service/map/useNearbyGoods.ts
+++ b/src/service/map/useNearbyGoods.ts
@@ -1,12 +1,24 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { IGoodsList } from '../../types/interface';
 
 export const useNearbyGoods = (payload: { lat: number; lng: number }) => {
-  const { refetch } = useQuery<IGoodsList[]>({
-    queryKey: [`nearby`, `${payload.lat}_${payload.lng}`],
-    queryFn: async () => (await axios.get(`/api/api/goods`, { params: payload })).data.content,
-    enabled: false,
+  const { data, isLoading, hasNextPage, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['nearby', `${payload.lat}_${payload.lng}`],
+    queryFn: async ({ pageParam }: { pageParam: number }) =>
+      (
+        await axios.get(`/api/api/goods`, {
+          params: {
+            lat: payload.lat,
+            lng: payload.lng,
+            page: pageParam,
+            size: 5,
+          },
+        })
+      ).data.content as IGoodsList[],
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, _, lastPageParams) =>
+      lastPage.length ? lastPageParams + 1 : undefined,
   });
-  return { refetch };
+  return { data, isLoading, hasNextPage, fetchNextPage };
 };

--- a/src/types/interface.ts
+++ b/src/types/interface.ts
@@ -1,3 +1,5 @@
+import { InfiniteQueryObserverResult } from '@tanstack/react-query';
+
 export type FormValueTypes = {
   email: string;
   password: string;
@@ -223,4 +225,13 @@ export interface IModal {
   handleSubmit: () => void;
   handleCloseModal: () => void;
   confirmBtnMsg: string;
+}
+
+export interface IObserver {
+  hasNext: boolean;
+  loadMore: () => Promise<InfiniteQueryObserverResult>;
+}
+
+export interface IBottomSheet extends IObserver {
+  products: IGoodsList[];
 }

--- a/src/util/useBottomSheet.ts
+++ b/src/util/useBottomSheet.ts
@@ -8,7 +8,7 @@ const useBottomSheet = () => {
   const prevIsOpen = usePreviousValue(isOpen);
 
   const onDragEnd = (info: PointerEvent) => {
-    const shouldClose = info?.y > 20 || (info?.y >= 0 && info.y > 45);
+    const shouldClose = info.y > 45;
 
     if (shouldClose) {
       controls.start('hidden');

--- a/src/util/useBottomSheet.ts
+++ b/src/util/useBottomSheet.ts
@@ -1,0 +1,33 @@
+import { useAnimation } from 'framer-motion';
+import { useEffect, useState } from 'react';
+import usePreviousValue from './usePreviousValue';
+
+const useBottomSheet = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const controls = useAnimation();
+  const prevIsOpen = usePreviousValue(isOpen);
+
+  const onDragEnd = (info: PointerEvent) => {
+    const shouldClose = info?.y > 20 || (info?.y >= 0 && info.y > 45);
+
+    if (shouldClose) {
+      controls.start('hidden');
+      setIsOpen(false);
+    } else {
+      controls.start('visible');
+      setIsOpen(true);
+    }
+  };
+
+  useEffect(() => {
+    if (prevIsOpen && !isOpen) {
+      controls.start('hidden');
+    } else if (!prevIsOpen && isOpen) {
+      controls.start('visible');
+    }
+  }, [controls, isOpen, prevIsOpen]);
+
+  return { onDragEnd, controls, setIsOpen, isOpen };
+};
+
+export default useBottomSheet;

--- a/src/util/useMemoHistory.ts
+++ b/src/util/useMemoHistory.ts
@@ -1,7 +1,7 @@
 import { InfiniteData } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
-export const useReduceHistory = <T>(data: InfiniteData<T[]>) => {
+export const useMemoHistory = <T>(data: InfiniteData<T[]>) => {
   const history = useMemo(() => {
     if (data) {
       return data.pages.reduce((acc, cur) => [...acc, ...cur], []);

--- a/src/util/usePreviousValue.ts
+++ b/src/util/usePreviousValue.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react';
+
+const usePreviousValue = (value: boolean) => {
+  //   const previousValueRef = useRef<HTMLDivElement>(null);
+  const [prev, setPrev] = useState(false);
+
+  useEffect(() => {
+    setPrev(value);
+  }, [value]);
+
+  return prev;
+};
+
+export default usePreviousValue;


### PR DESCRIPTION
### 의존성 추가
```
npm i framer-motion
```
### ⭐ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 문서 추가
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 📌 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

### ✨ 변경 사항

- 모바일 화면 UI개선을 위해 메인화면 리스트를 bottom sheet로 변경 했습니다.
- 메인화면 리스트에 무한 스크롤을 추가 했습니다.
- 마커도 페이지 별로 뜨고 있는데, 백엔드에서 전체를 받아오는 api가 추가 되면 수정 할 예정입니다.
- 현재 마커를 클릭하거나 검색 결과를 볼 때 리스트에 해당 상품만 뜨도록 돼 있는데, 이전의 요청으로 받은 데이터 중 위치 값이 일치하는 정보들만 프론트에서 필터링 해 띄우는 방식으로 구현 되어 있었습니다. 
 그러다 보니 페이지 형식이 아니게 되어서 마커를 클릭했을 때, 검색 결과를 볼 때는 무한 스크롤이 불가능 한 상황입니다. 
 그래서 마커를 클릭 할 때마다 서버에 요청을 보내서 페이지 형식으로 받아야 하나 생각을 해봤는데, 이에 대해서 어떻게 해결해야 할지 상의 해봐야 할 것 같습니다. 

### 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
